### PR TITLE
refacto: change PK due to publication date changing over time

### DIFF
--- a/postgres/insert_data.py
+++ b/postgres/insert_data.py
@@ -25,7 +25,6 @@ def add_primary_key(df):
         return (
             df["publication_name"]
             + df["news_title"]
-            + pd.to_datetime(df["news_publication_date"]).dt.strftime("%Y-%m-%d %X")
         ).apply(get_consistent_hash)
     except (Exception) as error:
         logging.warning(error)

--- a/test/sitemap/test_insert_data.py
+++ b/test/sitemap/test_insert_data.py
@@ -34,7 +34,7 @@ def test_add_primary_key():
                 "publication_name": "testpublication_name",
                 "news_title": "testnews_title",
                 "news_publication_date": pd.Timestamp("2023-10-11 13:10:00"),
-                "id": get_consistent_hash("testpublication_name" + "testnews_title" + "2023-10-11 13:10:00"),
+                "id": get_consistent_hash("testpublication_name" + "testnews_title"),
             }
         ]
     )
@@ -129,7 +129,7 @@ def test_insert_data_in_sitemap_table():
     insert_data_in_sitemap_table(df, conn)
 
     # check the value is well existing
-    primary_key = get_consistent_hash("testpublication_name_newtestnews_title2023-10-11 13:10:00")
+    primary_key = get_consistent_hash("testpublication_name_newtestnews_title")
     result = get_sitemap(primary_key)
 
     assert result.id == primary_key


### PR DESCRIPTION
Some medias changed their publication date instead of last modification, so it messed up the PK


To do after deployment :
* delete duplicate due to new PK

```
psql
>
BEGIN;
DELETE FROM
    sitemap_table a
        USING sitemap_table b
WHERE a.id != b.id AND a.news_title = b.news_title AND a.publication_name = b.publication_name
COMMIT;
```